### PR TITLE
feat: PR preview deployments + cleanup executor

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,169 @@ After the configuration is generated, you can deploy the project by running:
 ```bash
 nx run <project-name>:deploy
 ```
+
+## Pull Request Preview Deployments
+
+The `deploy` executor can also publish a pull request preview into a subdirectory of your `gh-pages` branch (e.g. `https://<you>.github.io/<repo>/pr/123/`) and post an updating comment on the pull request with the preview URL. A companion `cleanup-preview` executor removes stale previews on a schedule.
+
+### Generate a preview-enabled target
+
+```bash
+nx g nx-github-pages:configuration \
+  --project=<project-name> \
+  --preview \
+  --previewUrl=https://<you>.github.io/<repo> \
+  --addCleanupTarget
+```
+
+This creates two things on the project:
+
+```jsonc
+{
+  "deploy": {
+    "executor": "nx-github-pages:deploy",
+    "options": { /* ...production options... */ },
+    "configurations": {
+      "preview": {
+        "preview": { "url": "https://<you>.github.io/<repo>" },
+        "syncWithBaseBranch": true
+      }
+    }
+  },
+  "cleanup-previews": {
+    "executor": "nx-github-pages:cleanup-preview",
+    "options": {}
+  }
+}
+```
+
+### Preview executor options
+
+All standard `deploy` options still apply. Preview-specific options live under a `preview` object:
+
+| Option                | Default                                                    | Description                                                                     |
+| --------------------- | ---------------------------------------------------------- | ------------------------------------------------------------------------------- |
+| `preview.pathPrefix`  | `pr/${PR_NUMBER ?? GITHUB_SHA}`                            | Subdirectory on the target branch to deploy into.                               |
+| `preview.url`         | Derived from `CNAME` or `https://<owner>.github.io/<repo>` | Base URL used in the PR comment. The `pathPrefix` is appended automatically.    |
+| `preview.comment`     | `true`                                                     | Whether to upsert a PR comment with the preview link via the GitHub REST API.   |
+
+When preview mode is active the executor **clones** the target branch, copies the build output into `<pathPrefix>/`, and pushes without force — so sibling PR folders are preserved.
+
+### ⚠️ Your build MUST use a matching base URL
+
+Since the preview is served from a subdirectory, your framework needs to know about that subdirectory _at build time_, or every asset will 404 after deploy. The plugin **enforces this** by scanning the build output for references to the path prefix before pushing. If the check fails you'll get a descriptive error pointing at the right base URL flag for your framework.
+
+Pass the prefix to the build step as an environment variable and consume it in your framework config:
+
+```bash
+PATH_PREFIX="/pr/${PR_NUMBER:-$GITHUB_SHA}"
+
+# Vite
+npx nx build my-app -- --base="$PATH_PREFIX/"
+
+# Next.js (in next.config.js: basePath: process.env.NEXT_BASE_PATH)
+NEXT_BASE_PATH="$PATH_PREFIX" npx nx build my-app
+
+# Angular
+npx nx build my-app -- --base-href="$PATH_PREFIX/"
+
+# Astro
+npx nx build my-app -- --base="$PATH_PREFIX"
+```
+
+Then deploy with the preview configuration:
+
+```bash
+npx nx deploy my-app -c preview
+```
+
+If you serve previews through a CDN rewrite or some other scheme where the prefix legitimately does not appear in the built files, bypass the check with `NX_GITHUB_PAGES_SKIP_BASE_URL_CHECK=true`.
+
+### Required environment
+
+The executor auto-detects context from standard GitHub Actions environment variables:
+
+| Variable            | Source                       | Purpose                                           |
+| ------------------- | ---------------------------- | ------------------------------------------------- |
+| `GITHUB_REPOSITORY` | Actions runner               | Owner/repo for the PR comment.                    |
+| `GITHUB_REF`        | Actions runner               | Extracts the PR number from `refs/pull/<N>/merge`. |
+| `PR_NUMBER`         | Set it yourself              | Fallback for PR number; used in `pathPrefix`.     |
+| `GITHUB_SHA`        | Actions runner               | Included in the PR comment; fallback path prefix. |
+| `GH_TOKEN`          | `secrets.GITHUB_TOKEN` or PAT | Auth for `git push` **and** the Octokit comment.  |
+
+For the PR comment to work, install `@octokit/rest` in your workspace. It's declared as an optional peer dependency of the plugin:
+
+```bash
+npm install --save-dev @octokit/rest
+```
+
+### Example GitHub Actions workflow
+
+```yaml
+name: PR Preview
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  preview:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - run: npm ci
+
+      - name: Build with preview base URL
+        run: npx nx build my-app -- --base="$PATH_PREFIX/"
+        env:
+          PATH_PREFIX: /pr/${{ github.event.number }}
+
+      - name: Deploy preview
+        run: npx nx deploy my-app -c preview
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.number }}
+```
+
+### Cleaning up stale previews
+
+Add a scheduled workflow that runs the `cleanup-preview` executor. It clones the deployment branch, removes `pr/*` directories older than `maxAgeDays` (default `7`), and updates each corresponding PR comment to say the preview has been cleaned up.
+
+```yaml
+name: Cleanup PR Previews
+on:
+  schedule:
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+    inputs:
+      all:
+        description: 'Cleanup every preview regardless of age'
+        type: boolean
+        default: false
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm ci
+      - run: npx nx run my-app:cleanup-previews ${{ inputs.all && '--all' || '' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+```
+
+`cleanup-preview` options: `remote`, `baseBranch` (default `gh-pages`), `pathPrefix` (default `pr`), `maxAgeDays` (default `7`), `all` (default `false`), `updatePrComments` (default `true`).

--- a/packages/e2e/src/nx-github-pages.spec.ts
+++ b/packages/e2e/src/nx-github-pages.spec.ts
@@ -53,6 +53,107 @@ describe('nx-github-pages', () => {
     checkFilesExist(remoteDirectory, ['index.html']);
   });
 
+  it('should deploy a preview into a pr/<id> subdirectory and be cleaned up', () => {
+    const appName = 'my-app';
+    generateReactApp(projectDirectory, appName);
+    const nxProjectName = getNxProjectName(projectDirectory, appName);
+
+    // Patch the generated Vite config so `base` reads from a BASE_URL env
+    // var at build time. This is how consumers wire the preview path prefix
+    // into their framework, and it lets the plugin's base URL check find
+    // "/pr/42/" references in the actual built output.
+    patchViteConfigWithBaseUrl(projectDirectory, appName);
+
+    runCommand(
+      `npx nx g nx-github-pages:configuration --project ${nxProjectName} --preview --previewUrl https://example.github.io/test --addCleanupTarget --user.name deployment-bot --user.email deployment@testing.com --no-interactive`,
+      projectDirectory,
+      {}
+    );
+
+    const previewEnv = {
+      PR_NUMBER: '42',
+      GITHUB_SHA: 'deadbeefcafebabe1234567890abcdef12345678',
+      GITHUB_REPOSITORY: 'agentender/test-repo',
+      BASE_URL: '/pr/42/',
+    };
+
+    runCommand(
+      `npx nx deploy ${nxProjectName} -c preview --no-interactive`,
+      projectDirectory,
+      { env: { ...process.env, ...previewEnv } }
+    );
+
+    // Assert the preview landed in pr/42 on the gh-pages branch.
+    runCommand('git checkout gh-pages', remoteDirectory, {});
+    checkFilesExist(remoteDirectory, ['pr/42/index.html']);
+    // And that the built index.html actually carries the preview base URL —
+    // this is what the plugin's base URL safeguard is enforcing.
+    expect(
+      readFileSync(join(remoteDirectory, 'pr/42/index.html'), 'utf-8')
+    ).toContain('/pr/42/');
+
+    // Now run cleanup --all and verify the pr/42 directory is removed.
+    runCommand(
+      `npx nx run ${nxProjectName}:cleanup-previews --all --no-interactive`,
+      projectDirectory,
+      { env: { ...process.env, ...previewEnv } }
+    );
+
+    runCommand('git checkout gh-pages', remoteDirectory, {});
+    runCommand('git pull --ff-only origin gh-pages', remoteDirectory, {});
+    expect(existsSync(join(remoteDirectory, 'pr/42/index.html'))).toBe(false);
+  });
+
+  it('should fail the preview deploy when the build output lacks the path prefix', () => {
+    const appName = 'my-app';
+    generateReactApp(projectDirectory, appName);
+    const nxProjectName = getNxProjectName(projectDirectory, appName);
+
+    runCommand(
+      `npx nx g nx-github-pages:configuration --project ${nxProjectName} --preview --user.name deployment-bot --user.email deployment@testing.com --no-interactive`,
+      projectDirectory,
+      {}
+    );
+
+    const previewEnv = {
+      PR_NUMBER: '7',
+      GITHUB_SHA: 'abcdefabcdefabcdefabcdefabcdefabcdefabcd',
+      GITHUB_REPOSITORY: 'agentender/test-repo',
+    };
+
+    let caught: { status: number; stderr: string; stdout: string } | null =
+      null;
+    try {
+      execSync(
+        `npx nx deploy ${nxProjectName} -c preview --no-interactive`,
+        {
+          cwd: projectDirectory,
+          stdio: 'pipe',
+          env: { ...process.env, ...previewEnv },
+        }
+      );
+    } catch (err) {
+      const e = err as {
+        status: number;
+        stderr: Buffer;
+        stdout: Buffer;
+      };
+      caught = {
+        status: e.status,
+        stderr: e.stderr?.toString() ?? '',
+        stdout: e.stdout?.toString() ?? '',
+      };
+    }
+
+    if (!caught) {
+      throw new Error('Expected preview deploy to fail, but it succeeded.');
+    }
+    expect(caught.status).not.toBe(0);
+    const combined = caught.stderr + caught.stdout;
+    expect(combined).toMatch(/base URL check failed/i);
+    expect(combined).toMatch(/NX_GITHUB_PAGES_SKIP_BASE_URL_CHECK/);
+  });
+
   it('should sync via merge sync enabled and deployment already exists', () => {
     const appName = 'my-app';
 
@@ -282,6 +383,48 @@ function getNxProjectName(
   }
 
   return appName;
+}
+
+/**
+ * Patch the Vite config of a freshly generated @nx/react app so the `base`
+ * option is read from `process.env.BASE_URL` at build time. The plugin's
+ * base URL check then has something real to find in the build output when
+ * we run a preview deploy.
+ *
+ * Handles both the function-form `defineConfig(() => ({...}))` and the
+ * object-form `defineConfig({...})` that different Nx versions emit.
+ */
+function patchViteConfigWithBaseUrl(
+  projectDirectory: string,
+  appName: string
+): void {
+  const candidates = [
+    `apps/${appName}/vite.config.ts`,
+    `apps/${appName}/vite.config.mts`,
+    `apps/${appName}/vite.config.js`,
+  ];
+  const configPath = candidates.find((p) =>
+    existsSync(join(projectDirectory, p))
+  );
+  if (!configPath) {
+    throw new Error(
+      `Could not find a vite.config file under apps/${appName} — tried: ${candidates.join(', ')}`
+    );
+  }
+
+  updateFile(projectDirectory, configPath, (content) => {
+    // `root: __dirname` is a stable landmark emitted by every recent
+    // @nx/react Vite config generator. Insert `base` immediately before it.
+    if (!content.includes('root: __dirname')) {
+      throw new Error(
+        `Unexpected vite.config shape — 'root: __dirname' not found in ${configPath}`
+      );
+    }
+    return content.replace(
+      'root: __dirname',
+      `base: process.env.BASE_URL ?? '/',\n  root: __dirname`
+    );
+  });
 }
 
 function generateReactApp(projectDirectory: string, projectName: string) {

--- a/packages/e2e/src/nx-github-pages.spec.ts
+++ b/packages/e2e/src/nx-github-pages.spec.ts
@@ -413,16 +413,20 @@ function patchViteConfigWithBaseUrl(
   }
 
   updateFile(projectDirectory, configPath, (content) => {
-    // `root: __dirname` is a stable landmark emitted by every recent
-    // @nx/react Vite config generator. Insert `base` immediately before it.
-    if (!content.includes('root: __dirname')) {
+    // The `root:` field is a stable landmark emitted by every recent
+    // @nx/react Vite config generator. Its value is either `__dirname`
+    // (older CJS templates) or `import.meta.dirname` (newer ESM templates).
+    // Insert `base` immediately before it.
+    const rootLine = /^(\s*)root:\s*(?:__dirname|import\.meta\.dirname),/m;
+    if (!rootLine.test(content)) {
       throw new Error(
-        `Unexpected vite.config shape — 'root: __dirname' not found in ${configPath}`
+        `Unexpected vite.config shape — no 'root:' landmark found in ${configPath}`
       );
     }
     return content.replace(
-      'root: __dirname',
-      `base: process.env.BASE_URL ?? '/',\n  root: __dirname`
+      rootLine,
+      (match, indent) =>
+        `${indent}base: process.env.BASE_URL ?? '/',\n${match}`
     );
   });
 }

--- a/packages/e2e/src/nx-github-pages.spec.ts
+++ b/packages/e2e/src/nx-github-pages.spec.ts
@@ -93,14 +93,15 @@ describe('nx-github-pages', () => {
     ).toContain('/pr/42/');
 
     // Now run cleanup --all and verify the pr/42 directory is removed.
+    // The remote is configured with `receive.denyCurrentBranch=updateInstead`,
+    // so the cleanup push refreshes the remote's work tree in place — we can
+    // read the file state directly without another checkout.
     runCommand(
       `npx nx run ${nxProjectName}:cleanup-previews --all --no-interactive`,
       projectDirectory,
       { env: { ...process.env, ...previewEnv } }
     );
 
-    runCommand('git checkout gh-pages', remoteDirectory, {});
-    runCommand('git pull --ff-only origin gh-pages', remoteDirectory, {});
     expect(existsSync(join(remoteDirectory, 'pr/42/index.html'))).toBe(false);
   });
 
@@ -287,6 +288,16 @@ function createTestRemote() {
   });
 
   execSync('git init', {
+    cwd: remoteDirectory,
+    stdio: 'inherit',
+  });
+
+  // The test remote is a non-bare repo. When a test checks out `gh-pages` in
+  // the work tree (to assert deployed files exist) and then a subsequent step
+  // pushes back to `gh-pages` on the same remote, git refuses by default with
+  // `denyCurrentBranch`. `updateInstead` lets the push succeed and also
+  // refreshes the work tree so later assertions see the latest state.
+  execSync('git config receive.denyCurrentBranch updateInstead', {
     cwd: remoteDirectory,
     stdio: 'inherit',
   });

--- a/packages/nx-github-pages/.eslintrc.json
+++ b/packages/nx-github-pages/.eslintrc.json
@@ -23,7 +23,12 @@
         "@nx/dependency-checks": [
           "error",
           {
-            "ignoredDependencies": ["@nx/jest", "@nx/js", "nx"]
+            "ignoredDependencies": [
+              "@nx/jest",
+              "@nx/js",
+              "nx",
+              "@octokit/rest"
+            ]
           }
         ]
       }

--- a/packages/nx-github-pages/executors.json
+++ b/packages/nx-github-pages/executors.json
@@ -4,6 +4,11 @@
       "implementation": "./src/executors/deploy/executor",
       "schema": "./src/executors/deploy/schema.json",
       "description": "deploy executor"
+    },
+    "cleanup-preview": {
+      "implementation": "./src/executors/cleanup-preview/executor",
+      "schema": "./src/executors/cleanup-preview/schema.json",
+      "description": "Remove stale PR preview deployments from the gh-pages branch"
     }
   }
 }

--- a/packages/nx-github-pages/package.json
+++ b/packages/nx-github-pages/package.json
@@ -17,6 +17,14 @@
     "enquirer": "^2.4.1",
     "tslib": "^2.3.0"
   },
+  "peerDependencies": {
+    "@octokit/rest": "^21.0.0"
+  },
+  "peerDependenciesMeta": {
+    "@octokit/rest": {
+      "optional": true
+    }
+  },
   "devDependencies": {},
   "type": "commonjs",
   "main": "./src/index.js",

--- a/packages/nx-github-pages/src/executors/cleanup-preview/executor.ts
+++ b/packages/nx-github-pages/src/executors/cleanup-preview/executor.ts
@@ -1,0 +1,169 @@
+import { ExecutorContext, logger } from '@nx/devkit';
+import { existsSync, mkdtempSync, readdirSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+import { exec } from '../../utils/exec';
+import { findDefaultRemote } from '../../utils/find-default-remote';
+import { parseOwnerRepoFromRemote } from '../../utils/github-context';
+import { markPreviewCommentCleaned } from '../../utils/preview-comment';
+import { CleanupPreviewExecutorSchema } from './schema';
+
+function normalizeRemote(remote: string): string {
+  const token = process.env.GH_TOKEN ?? process.env.GITHUB_TOKEN;
+  if (!token) return remote;
+  if (remote.startsWith('git@')) {
+    remote = remote.replace('git@', 'https://');
+  }
+  if (remote.startsWith('https://') && !/:.*@/.test(remote)) {
+    return remote.replace('https://', `https://github-actions:${token}@`);
+  }
+  return remote;
+}
+
+async function getLastCommitTimestamp(
+  cwd: string,
+  path: string
+): Promise<number> {
+  const out = await exec(
+    `git log -n 1 --pretty=format:%at -- "${path}"`,
+    { cwd, stdio: 'ignore' }
+  );
+  const seconds = Number(out.trim());
+  if (Number.isNaN(seconds)) return 0;
+  return seconds * 1000;
+}
+
+export default async function cleanupPreviewExecutor(
+  options: CleanupPreviewExecutorSchema,
+  context: ExecutorContext
+): Promise<{ success: boolean }> {
+  const rawRemote =
+    options.remote ?? (await findDefaultRemote(context.root).catch(() => ''));
+  if (!rawRemote) {
+    logger.error(
+      'No remote configured — pass `remote` or run inside a git repo with an origin.'
+    );
+    return { success: false };
+  }
+  const remote = normalizeRemote(rawRemote);
+  const baseBranch = options.baseBranch;
+  const pathPrefix = options.pathPrefix.replace(/^\/+|\/+$/g, '');
+
+  const scratch = mkdtempSync(join(tmpdir(), 'nx-ghp-cleanup-'));
+  try {
+    logger.info(`Cloning ${rawRemote}@${baseBranch}`);
+    await exec(
+      `git clone --single-branch --branch ${baseBranch} "${remote}" .`,
+      { cwd: scratch }
+    );
+
+    // Configure git user for the eventual cleanup commit.
+    if (options.user) {
+      await exec(`git config user.email ${options.user.email}`, {
+        cwd: scratch,
+      });
+      await exec(`git config user.name "${options.user.name}"`, {
+        cwd: scratch,
+      });
+    } else if (
+      process.env.GITHUB_ACTIONS === 'true' &&
+      process.env.GITHUB_ACTOR
+    ) {
+      await exec(
+        `git config user.email ${process.env.GITHUB_ACTOR}@users.noreply.github.com`,
+        { cwd: scratch }
+      );
+      await exec(`git config user.name "${process.env.GITHUB_ACTOR}"`, {
+        cwd: scratch,
+      });
+    }
+
+    const prRoot = join(scratch, pathPrefix);
+    if (!existsSync(prRoot)) {
+      logger.info(
+        `No '${pathPrefix}' directory on ${baseBranch} — nothing to clean up.`
+      );
+      return { success: true };
+    }
+
+    const now = Date.now();
+    const maxAgeMs = options.maxAgeDays * 24 * 60 * 60 * 1000;
+    const parsedRepo = parseOwnerRepoFromRemote(rawRemote);
+
+    const folders = readdirSync(prRoot);
+    const removed: string[] = [];
+    for (const folder of folders) {
+      const relPath = `${pathPrefix}/${folder}`;
+      const lastModified = await getLastCommitTimestamp(scratch, relPath);
+      const ageMs = now - lastModified;
+      const shouldRemove = options.all || ageMs > maxAgeMs;
+      if (!shouldRemove) {
+        continue;
+      }
+      logger.info(
+        `Removing ${relPath} (age: ${Math.round(ageMs / (24 * 60 * 60 * 1000))} days)`
+      );
+      rmSync(join(scratch, relPath), { recursive: true, force: true });
+      removed.push(folder);
+
+      if (options.updatePrComments && parsedRepo) {
+        const prNumber = Number(folder);
+        if (!Number.isNaN(prNumber)) {
+          try {
+            await markPreviewCommentCleaned(
+              parsedRepo.owner,
+              parsedRepo.repo,
+              prNumber
+            );
+          } catch (err) {
+            logger.warn(
+              `Failed to update PR comment for #${prNumber}: ${
+                err instanceof Error ? err.message : String(err)
+              }`
+            );
+          }
+        }
+      }
+    }
+
+    if (removed.length === 0) {
+      logger.info('No preview deployments matched cleanup criteria.');
+      return { success: true };
+    }
+
+    await exec(`git add -A`, { cwd: scratch });
+    const staged = await exec(`git diff --name-only --cached`, {
+      cwd: scratch,
+      stdio: 'ignore',
+    });
+    if (staged.split('\n').filter((l) => l.trim()).length === 0) {
+      logger.info('No file changes after removal — skipping commit.');
+      return { success: true };
+    }
+
+    await exec(`git commit -m "${options.commitMessage}"`, { cwd: scratch });
+    try {
+      await exec(`git push ${options.remoteName} ${baseBranch}`, {
+        cwd: scratch,
+      });
+    } catch (err) {
+      logger.error(
+        'Cleanup push failed — ensure GH_TOKEN/GITHUB_TOKEN has write access.'
+      );
+      throw err;
+    }
+
+    logger.info(
+      `Cleaned up ${removed.length} preview deployment(s): ${removed.join(', ')}`
+    );
+    return { success: true };
+  } catch (err) {
+    logger.error(
+      `cleanup-preview failed: ${err instanceof Error ? err.message : String(err)}`
+    );
+    return { success: false };
+  } finally {
+    rmSync(scratch, { recursive: true, force: true });
+  }
+}

--- a/packages/nx-github-pages/src/executors/cleanup-preview/schema.d.ts
+++ b/packages/nx-github-pages/src/executors/cleanup-preview/schema.d.ts
@@ -1,0 +1,14 @@
+export interface CleanupPreviewExecutorSchema {
+  remote?: string;
+  remoteName: string;
+  baseBranch: string;
+  pathPrefix: string;
+  maxAgeDays: number;
+  all: boolean;
+  updatePrComments: boolean;
+  commitMessage: string;
+  user?: {
+    name: string;
+    email: string;
+  };
+}

--- a/packages/nx-github-pages/src/executors/cleanup-preview/schema.json
+++ b/packages/nx-github-pages/src/executors/cleanup-preview/schema.json
@@ -1,0 +1,57 @@
+{
+  "version": 2,
+  "$schema": "http://json-schema.org/schema",
+  "title": "Cleanup Preview Deployments",
+  "description": "Remove old preview deployments from the target gh-pages branch and update the associated PR comments.",
+  "type": "object",
+  "properties": {
+    "remote": {
+      "type": "string",
+      "description": "URL for the git remote containing the preview deployments. Defaults to the project's origin remote."
+    },
+    "remoteName": {
+      "type": "string",
+      "description": "Name of the remote to push to",
+      "default": "origin"
+    },
+    "baseBranch": {
+      "type": "string",
+      "description": "Branch that hosts the deployed site",
+      "default": "gh-pages"
+    },
+    "pathPrefix": {
+      "type": "string",
+      "description": "Top-level directory on the deployment branch that contains per-PR subdirectories",
+      "default": "pr"
+    },
+    "maxAgeDays": {
+      "type": "number",
+      "description": "Delete preview directories whose most recent commit is older than this many days",
+      "default": 7
+    },
+    "all": {
+      "type": "boolean",
+      "description": "Delete every preview directory regardless of age",
+      "default": false
+    },
+    "updatePrComments": {
+      "type": "boolean",
+      "description": "Update the preview deployment PR comment for each cleaned directory",
+      "default": true
+    },
+    "commitMessage": {
+      "type": "string",
+      "description": "Commit message used for the cleanup commit",
+      "default": "chore: cleanup old preview deployments [skip ci]"
+    },
+    "user": {
+      "type": "object",
+      "description": "User information used when authoring the cleanup commit",
+      "properties": {
+        "name": { "type": "string" },
+        "email": { "type": "string" }
+      }
+    }
+  },
+  "required": []
+}

--- a/packages/nx-github-pages/src/executors/deploy/executor.ts
+++ b/packages/nx-github-pages/src/executors/deploy/executor.ts
@@ -4,11 +4,11 @@ import { stat, writeFileSync } from 'fs';
 import { join } from 'path';
 
 import { DeployExecutorSchema } from './schema';
+import { deployPreview } from './preview';
 
 import { findDefaultBuildDirectory } from '../../utils/find-default-build-directory';
 import { exec } from '../../utils/exec';
 import { findDefaultRemote } from '../../utils/find-default-remote';
-import { cwd } from 'process';
 
 async function normalizeOptions(
   options: DeployExecutorSchema,
@@ -74,6 +74,19 @@ export default async function deployExecutor(
     return {
       success: false,
     };
+  }
+
+  if (options.preview) {
+    try {
+      return await deployPreview(options.preview, options, directory);
+    } catch (err) {
+      logger.error(
+        `Preview deploy failed: ${
+          err instanceof Error ? err.message : String(err)
+        }`
+      );
+      return { success: false };
+    }
   }
 
   if (options.CNAME) {

--- a/packages/nx-github-pages/src/executors/deploy/preview.ts
+++ b/packages/nx-github-pages/src/executors/deploy/preview.ts
@@ -9,6 +9,7 @@ import {
   parseOwnerRepoFromRemote,
 } from '../../utils/github-context';
 import { upsertPreviewComment } from '../../utils/preview-comment';
+import { assertBaseUrlInBundle } from '../../utils/verify-base-url';
 import { DeployExecutorSchema, PreviewOptions } from './schema';
 
 export interface NormalizedDeployOptions
@@ -89,6 +90,10 @@ export async function deployPreview(
   logger.info(
     `Preview deploy: pushing to ${remote}@${baseBranch} under '${pathPrefix}'`
   );
+
+  // Fail fast if the built bundle doesn't reference the preview path prefix.
+  // Without a matching BASE_URL, every asset 404s after deployment.
+  assertBaseUrlInBundle(sourceDirectory, pathPrefix);
 
   const scratch = mkdtempSync(join(tmpdir(), 'nx-ghp-preview-'));
   try {

--- a/packages/nx-github-pages/src/executors/deploy/preview.ts
+++ b/packages/nx-github-pages/src/executors/deploy/preview.ts
@@ -1,0 +1,188 @@
+import { logger } from '@nx/devkit';
+import { cpSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+import { exec } from '../../utils/exec';
+import {
+  getGitHubContext,
+  parseOwnerRepoFromRemote,
+} from '../../utils/github-context';
+import { upsertPreviewComment } from '../../utils/preview-comment';
+import { DeployExecutorSchema, PreviewOptions } from './schema';
+
+export interface NormalizedDeployOptions
+  extends Omit<DeployExecutorSchema, 'preview'> {
+  remote: string;
+  directory: string;
+}
+
+function resolvePathPrefix(explicit: string | undefined): string {
+  if (explicit) {
+    return explicit.replace(/^\/+|\/+$/g, '');
+  }
+  const prNumber = process.env.PR_NUMBER;
+  const sha = process.env.GITHUB_SHA;
+  const id = prNumber || sha;
+  if (!id) {
+    throw new Error(
+      'Unable to determine preview path prefix: set PR_NUMBER or GITHUB_SHA, or provide preview.pathPrefix explicitly.'
+    );
+  }
+  return `pr/${id}`;
+}
+
+function resolvePreviewUrl(
+  preview: PreviewOptions,
+  pathPrefix: string,
+  options: NormalizedDeployOptions,
+  remote: string
+): string | null {
+  const trimmed = (preview.url ?? '').replace(/\/+$/, '');
+  if (trimmed) {
+    return `${trimmed}/${pathPrefix}`;
+  }
+  if (options.CNAME) {
+    return `https://${options.CNAME}/${pathPrefix}`;
+  }
+  const parsed = parseOwnerRepoFromRemote(remote);
+  if (parsed) {
+    // Default GitHub Pages URL: https://<owner>.github.io/<repo>/<pathPrefix>
+    return `https://${parsed.owner}.github.io/${parsed.repo}/${pathPrefix}`;
+  }
+  return null;
+}
+
+async function configureGitUser(
+  cwd: string,
+  options: NormalizedDeployOptions
+): Promise<void> {
+  if (options.user) {
+    await exec(`git config user.email ${options.user.email}`, { cwd });
+    await exec(`git config user.name "${options.user.name}"`, { cwd });
+    return;
+  }
+  if (
+    process.env.GITHUB_ACTIONS === 'true' &&
+    process.env.GITHUB_ACTOR &&
+    !(await exec('git config user.email', { cwd, stdio: 'ignore' }).catch(
+      () => ''
+    ))
+  ) {
+    await exec(
+      `git config user.email ${process.env.GITHUB_ACTOR}@users.noreply.github.com`,
+      { cwd }
+    );
+    await exec(`git config user.name "${process.env.GITHUB_ACTOR}"`, { cwd });
+  }
+}
+
+export async function deployPreview(
+  preview: PreviewOptions,
+  options: NormalizedDeployOptions,
+  sourceDirectory: string
+): Promise<{ success: boolean }> {
+  const pathPrefix = resolvePathPrefix(preview.pathPrefix);
+  const remote = options.remote;
+  const baseBranch = options.baseBranch || 'gh-pages';
+
+  logger.info(
+    `Preview deploy: pushing to ${remote}@${baseBranch} under '${pathPrefix}'`
+  );
+
+  const scratch = mkdtempSync(join(tmpdir(), 'nx-ghp-preview-'));
+  try {
+    // Try to clone the existing base branch. If it doesn't exist yet,
+    // initialize an empty one so the first preview still works.
+    let hasExistingBranch = true;
+    try {
+      await exec(
+        `git clone --depth 1 --single-branch --branch ${baseBranch} "${remote}" .`,
+        { cwd: scratch }
+      );
+    } catch {
+      hasExistingBranch = false;
+      logger.info(
+        `Base branch '${baseBranch}' not found on remote — initializing a new one.`
+      );
+      await exec(`git init`, { cwd: scratch });
+      await exec(`git checkout -b ${baseBranch}`, { cwd: scratch });
+      await exec(`git remote add ${options.remoteName} "${remote}"`, {
+        cwd: scratch,
+      });
+    }
+
+    await configureGitUser(scratch, options);
+
+    // Wipe the target subdirectory so file deletions in the build are
+    // reflected in the deployment.
+    const targetDir = join(scratch, pathPrefix);
+    rmSync(targetDir, { recursive: true, force: true });
+    mkdirSync(targetDir, { recursive: true });
+    cpSync(sourceDirectory, targetDir, { recursive: true });
+
+    if (options.CNAME) {
+      writeFileSync(join(scratch, 'CNAME'), options.CNAME);
+    }
+
+    await exec(`git add -A`, { cwd: scratch });
+    const staged = await exec(`git diff --name-only --cached`, {
+      cwd: scratch,
+      stdio: 'ignore',
+    });
+    if (staged.split('\n').filter((l) => l.trim()).length === 0) {
+      logger.info('No changes to deploy — skipping commit & push.');
+    } else {
+      await exec(`git commit -m "${options.commitMessage} (${pathPrefix})"`, {
+        cwd: scratch,
+      });
+      const pushTarget = hasExistingBranch
+        ? `${options.remoteName} ${baseBranch}`
+        : `--set-upstream ${options.remoteName} ${baseBranch}`;
+      try {
+        await exec(`git push ${pushTarget}`, { cwd: scratch });
+      } catch (err) {
+        logger.error(
+          'Preview push failed. Ensure GH_TOKEN/GITHUB_TOKEN has write access to the target repository.'
+        );
+        throw err;
+      }
+    }
+
+    // Post/update the PR comment.
+    if (preview.comment !== false) {
+      const ghContext = getGitHubContext();
+      const fallback = parseOwnerRepoFromRemote(remote);
+      const owner = ghContext?.owner ?? fallback?.owner;
+      const repo = ghContext?.repo ?? fallback?.repo;
+      const prNumber = ghContext?.prNumber;
+      const url = resolvePreviewUrl(preview, pathPrefix, options, remote);
+
+      if (!owner || !repo) {
+        logger.warn(
+          'Skipping PR comment: could not determine owner/repo. Set GITHUB_REPOSITORY or use a github.com remote URL.'
+        );
+      } else if (!prNumber) {
+        logger.warn(
+          'Skipping PR comment: no pull request number detected. Set PR_NUMBER or run inside a pull_request workflow.'
+        );
+      } else if (!url) {
+        logger.warn(
+          'Skipping PR comment: could not determine preview URL. Set preview.url or CNAME.'
+        );
+      } else {
+        await upsertPreviewComment({
+          owner,
+          repo,
+          prNumber,
+          url,
+          sha: ghContext?.sha,
+        });
+      }
+    }
+
+    return { success: true };
+  } finally {
+    rmSync(scratch, { recursive: true, force: true });
+  }
+}

--- a/packages/nx-github-pages/src/executors/deploy/schema.d.ts
+++ b/packages/nx-github-pages/src/executors/deploy/schema.d.ts
@@ -8,8 +8,15 @@ export interface DeployExecutorSchema {
   syncStrategy: 'rebase' | 'merge';
   syncGitOptions: string[];
   CNAME?: string;
+  preview?: false | PreviewOptions;
   user?: {
     email: string;
     name: string;
   };
+}
+
+export interface PreviewOptions {
+  url?: string;
+  pathPrefix?: string;
+  comment?: boolean;
 }

--- a/packages/nx-github-pages/src/executors/deploy/schema.json
+++ b/packages/nx-github-pages/src/executors/deploy/schema.json
@@ -51,6 +51,32 @@
       "type": "string",
       "description": "Custom domain to use for the gh-pages branch. Applied by creating a CNAME file in the root of the gh-pages branch"
     },
+    "preview": {
+      "description": "When set to an object, deploys the build output into a subdirectory of the target branch (instead of replacing it) and optionally comments on the associated pull request. Set to `false` (the default) for a standard deploy.",
+      "default": false,
+      "oneOf": [
+        { "const": false },
+        {
+          "type": "object",
+          "properties": {
+            "url": {
+              "type": "string",
+              "description": "Base URL where the preview will be available. Used in the PR comment. If omitted, derived from the `CNAME` option or the GitHub Pages default domain for the target remote."
+            },
+            "pathPrefix": {
+              "type": "string",
+              "description": "Subdirectory within the target branch to deploy into. Defaults to `pr/${PR_NUMBER}` (or `pr/${GITHUB_SHA}` if no PR number is available)."
+            },
+            "comment": {
+              "type": "boolean",
+              "description": "Whether to upsert a comment on the pull request with the preview URL. Requires a PR context and a `GH_TOKEN`/`GITHUB_TOKEN` with `pull-requests: write`.",
+              "default": true
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
+    },
     "user": {
       "type": "object",
       "description": "User information to use when authoring deployment commit",

--- a/packages/nx-github-pages/src/generators/configuration/generator.ts
+++ b/packages/nx-github-pages/src/generators/configuration/generator.ts
@@ -53,6 +53,18 @@ export async function configurationGenerator(
     },
   };
 
+  if (options.preview) {
+    targetDefinition.configurations = {
+      ...targetDefinition.configurations,
+      preview: {
+        preview: {
+          ...(options.previewUrl ? { url: options.previewUrl } : {}),
+        },
+        syncWithBaseBranch: true,
+      },
+    };
+  }
+
   try {
     findDefaultBuildDirectory({
       projectName: options.project,
@@ -88,11 +100,20 @@ export async function configurationGenerator(
     }).then((answer) => answer.remote);
   }
 
+  const extraTargets: Record<string, TargetConfiguration> = {};
+  if (options.addCleanupTarget) {
+    extraTargets['cleanup-previews'] = {
+      executor: 'nx-github-pages:cleanup-preview',
+      options: {},
+    };
+  }
+
   if (!onDisk) {
     addProjectConfiguration(tree, options.project, {
       root: project.root,
       targets: {
         [options.targetName]: targetDefinition,
+        ...extraTargets,
       },
     });
   } else {
@@ -101,6 +122,7 @@ export async function configurationGenerator(
       targets: {
         ...project.targets,
         [options.targetName]: targetDefinition,
+        ...extraTargets,
       },
     });
   }

--- a/packages/nx-github-pages/src/generators/configuration/schema.d.ts
+++ b/packages/nx-github-pages/src/generators/configuration/schema.d.ts
@@ -1,6 +1,9 @@
 export interface ConfigurationGeneratorSchema {
   project: string;
   targetName: string;
+  preview?: boolean;
+  previewUrl?: string;
+  addCleanupTarget?: boolean;
   user?: {
     email: string;
     name: string;

--- a/packages/nx-github-pages/src/generators/configuration/schema.json
+++ b/packages/nx-github-pages/src/generators/configuration/schema.json
@@ -33,6 +33,20 @@
       "type": "string",
       "description": "The name of the target to add.",
       "default": "deploy"
+    },
+    "preview": {
+      "type": "boolean",
+      "description": "Add a `preview` configuration to the deploy target that deploys into a PR subdirectory and comments on the pull request.",
+      "default": false
+    },
+    "previewUrl": {
+      "type": "string",
+      "description": "Base URL where previews will be hosted (used to build the PR comment link). Only applied when `preview` is true."
+    },
+    "addCleanupTarget": {
+      "type": "boolean",
+      "description": "Also add a `cleanup-previews` target that removes stale PR preview deployments.",
+      "default": false
     }
   },
   "required": ["project"]

--- a/packages/nx-github-pages/src/utils/github-context.ts
+++ b/packages/nx-github-pages/src/utils/github-context.ts
@@ -1,0 +1,43 @@
+export interface GitHubContext {
+  owner: string;
+  repo: string;
+  prNumber?: number;
+  sha?: string;
+}
+
+export function getGitHubContext(): GitHubContext | null {
+  const repository = process.env.GITHUB_REPOSITORY;
+  if (!repository || !repository.includes('/')) {
+    return null;
+  }
+  const [owner, repo] = repository.split('/');
+
+  let prNumber: number | undefined;
+  const refName = process.env.GITHUB_REF ?? '';
+  const prMatch = refName.match(/^refs\/pull\/(\d+)\//);
+  if (prMatch) {
+    prNumber = Number(prMatch[1]);
+  } else if (process.env.PR_NUMBER) {
+    const parsed = Number(process.env.PR_NUMBER);
+    if (!Number.isNaN(parsed)) {
+      prNumber = parsed;
+    }
+  }
+
+  return {
+    owner,
+    repo,
+    prNumber,
+    sha: process.env.GITHUB_SHA,
+  };
+}
+
+export function parseOwnerRepoFromRemote(
+  remote: string
+): { owner: string; repo: string } | null {
+  const match = remote.match(
+    /github\.com[/:]([^/]+)\/([^/.]+?)(?:\.git)?(?:\/)?$/i
+  );
+  if (!match) return null;
+  return { owner: match[1], repo: match[2] };
+}

--- a/packages/nx-github-pages/src/utils/preview-comment.ts
+++ b/packages/nx-github-pages/src/utils/preview-comment.ts
@@ -1,0 +1,142 @@
+import { logger } from '@nx/devkit';
+
+const PREVIEW_MARKER = '<!-- nx-github-pages:preview-deployment -->';
+
+export interface PreviewCommentInput {
+  owner: string;
+  repo: string;
+  prNumber: number;
+  url: string;
+  sha?: string;
+}
+
+function renderBody(input: PreviewCommentInput): string {
+  const rows = [
+    ['URL', `[${input.url}](${input.url})`],
+    ['Commit', input.sha ? `\`${input.sha}\`` : '—'],
+    ['Deployed at', new Date().toISOString()],
+  ];
+  const table = [
+    '|   |   |',
+    '| - | - |',
+    ...rows.map(([k, v]) => `| ${k} | ${v} |`),
+  ].join('\n');
+  return [
+    PREVIEW_MARKER,
+    '# Preview Deployment',
+    'Thanks for contributing to this PR 🎉',
+    '',
+    table,
+  ].join('\n');
+}
+
+function renderCleanupBody(): string {
+  return [
+    PREVIEW_MARKER,
+    '# Preview Deployment',
+    '',
+    'Preview deployment has been cleaned up. Push a new commit to re-deploy.',
+  ].join('\n');
+}
+
+async function loadOctokit(): Promise<
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  { Octokit: new (opts: { auth?: string }) => any } | null
+> {
+  try {
+    // Resolved at runtime — @octokit/rest is a peer/optional dep of the plugin.
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    return require('@octokit/rest');
+  } catch {
+    logger.warn(
+      'Failed to load @octokit/rest — install it as a dependency of your workspace to enable PR preview comments.'
+    );
+    return null;
+  }
+}
+
+function getToken(): string | undefined {
+  return process.env.GH_TOKEN ?? process.env.GITHUB_TOKEN;
+}
+
+async function findPreviewComment(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  client: any,
+  owner: string,
+  repo: string,
+  prNumber: number
+) {
+  const { data } = await client.rest.issues.listComments({
+    owner,
+    repo,
+    issue_number: prNumber,
+    per_page: 100,
+  });
+  return data.find(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (c: any) =>
+      c.body?.includes(PREVIEW_MARKER) ||
+      c.body?.toLowerCase().includes('preview deployment')
+  );
+}
+
+export async function upsertPreviewComment(
+  input: PreviewCommentInput
+): Promise<void> {
+  const token = getToken();
+  if (!token) {
+    logger.warn(
+      'No GH_TOKEN/GITHUB_TOKEN found — skipping preview deployment PR comment.'
+    );
+    return;
+  }
+  const mod = await loadOctokit();
+  if (!mod) return;
+
+  const client = new mod.Octokit({ auth: token });
+  const body = renderBody(input);
+
+  const existing = await findPreviewComment(
+    client,
+    input.owner,
+    input.repo,
+    input.prNumber
+  );
+  if (existing) {
+    await client.rest.issues.updateComment({
+      owner: input.owner,
+      repo: input.repo,
+      comment_id: existing.id,
+      body,
+    });
+    logger.info(`Updated preview deployment comment on PR #${input.prNumber}`);
+  } else {
+    await client.rest.issues.createComment({
+      owner: input.owner,
+      repo: input.repo,
+      issue_number: input.prNumber,
+      body,
+    });
+    logger.info(`Created preview deployment comment on PR #${input.prNumber}`);
+  }
+}
+
+export async function markPreviewCommentCleaned(
+  owner: string,
+  repo: string,
+  prNumber: number
+): Promise<void> {
+  const token = getToken();
+  if (!token) return;
+  const mod = await loadOctokit();
+  if (!mod) return;
+  const client = new mod.Octokit({ auth: token });
+  const existing = await findPreviewComment(client, owner, repo, prNumber);
+  if (!existing) return;
+  await client.rest.issues.updateComment({
+    owner,
+    repo,
+    comment_id: existing.id,
+    body: renderCleanupBody(),
+  });
+}

--- a/packages/nx-github-pages/src/utils/verify-base-url.spec.ts
+++ b/packages/nx-github-pages/src/utils/verify-base-url.spec.ts
@@ -1,0 +1,98 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+import {
+  SKIP_ENV_VAR,
+  assertBaseUrlInBundle,
+  verifyBaseUrlInBundle,
+} from './verify-base-url';
+
+describe('verify-base-url', () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'nx-ghp-verify-'));
+    delete process.env[SKIP_ENV_VAR];
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+    delete process.env[SKIP_ENV_VAR];
+  });
+
+  it('passes when the path prefix appears in an HTML asset reference', () => {
+    writeFileSync(
+      join(dir, 'index.html'),
+      '<html><head><script src="/pr/123/assets/main.js"></script></head></html>'
+    );
+
+    const result = verifyBaseUrlInBundle(dir, 'pr/123');
+    expect(result.ok).toBe(true);
+    expect(result.matchedFile).toContain('index.html');
+  });
+
+  it('passes when the path prefix appears in a nested JS file', () => {
+    mkdirSync(join(dir, 'assets'), { recursive: true });
+    writeFileSync(join(dir, 'index.html'), '<html><body></body></html>');
+    writeFileSync(
+      join(dir, 'assets', 'main.js'),
+      'const base = "/pr/42/";\nfetch(base + "data.json");'
+    );
+
+    const result = verifyBaseUrlInBundle(dir, '/pr/42/');
+    expect(result.ok).toBe(true);
+  });
+
+  it('fails when the path prefix is not found anywhere', () => {
+    writeFileSync(
+      join(dir, 'index.html'),
+      '<html><head><script src="/assets/main.js"></script></head></html>'
+    );
+
+    const result = verifyBaseUrlInBundle(dir, 'pr/123');
+    expect(result.ok).toBe(false);
+    expect(result.scannedFiles).toBeGreaterThan(0);
+  });
+
+  it('skips directories like node_modules and .git', () => {
+    mkdirSync(join(dir, 'node_modules'), { recursive: true });
+    mkdirSync(join(dir, '.git'), { recursive: true });
+    // These files contain the needle but should NOT count.
+    writeFileSync(join(dir, 'node_modules', 'fake.js'), '"pr/999"');
+    writeFileSync(join(dir, '.git', 'HEAD'), 'pr/999');
+    writeFileSync(
+      join(dir, 'index.html'),
+      '<html><body>nothing here</body></html>'
+    );
+
+    const result = verifyBaseUrlInBundle(dir, 'pr/999');
+    expect(result.ok).toBe(false);
+  });
+
+  describe('assertBaseUrlInBundle', () => {
+    it('throws a descriptive error when check fails', () => {
+      writeFileSync(join(dir, 'index.html'), '<html></html>');
+      expect(() => assertBaseUrlInBundle(dir, 'pr/7')).toThrow(
+        /Preview deploy base URL check failed/
+      );
+      expect(() => assertBaseUrlInBundle(dir, 'pr/7')).toThrow(
+        /NX_GITHUB_PAGES_SKIP_BASE_URL_CHECK=true/
+      );
+    });
+
+    it('does not throw when the env var bypass is set', () => {
+      writeFileSync(join(dir, 'index.html'), '<html></html>');
+      process.env[SKIP_ENV_VAR] = 'true';
+      expect(() => assertBaseUrlInBundle(dir, 'pr/7')).not.toThrow();
+    });
+
+    it('does not throw when the check passes', () => {
+      writeFileSync(
+        join(dir, 'index.html'),
+        '<html><script src="/pr/7/main.js"></script></html>'
+      );
+      expect(() => assertBaseUrlInBundle(dir, 'pr/7')).not.toThrow();
+    });
+  });
+});

--- a/packages/nx-github-pages/src/utils/verify-base-url.ts
+++ b/packages/nx-github-pages/src/utils/verify-base-url.ts
@@ -1,0 +1,122 @@
+import { logger } from '@nx/devkit';
+import type { Dirent } from 'fs';
+import { readdirSync, readFileSync, statSync } from 'fs';
+import { join } from 'path';
+
+export const SKIP_ENV_VAR = 'NX_GITHUB_PAGES_SKIP_BASE_URL_CHECK';
+
+const SCANNED_EXTENSIONS = new Set([
+  '.html',
+  '.htm',
+  '.js',
+  '.mjs',
+  '.cjs',
+  '.css',
+  '.map',
+  '.json',
+]);
+
+const MAX_FILES = 500;
+const MAX_BYTES_PER_FILE = 10 * 1024 * 1024;
+
+function* walk(dir: string): Generator<string> {
+  let entries: Dirent[];
+  try {
+    entries = readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return;
+  }
+  for (const entry of entries) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name === '.git' || entry.name === 'node_modules') continue;
+      yield* walk(full);
+    } else if (entry.isFile()) {
+      const dotIdx = entry.name.lastIndexOf('.');
+      if (dotIdx < 0) continue;
+      const ext = entry.name.slice(dotIdx).toLowerCase();
+      if (SCANNED_EXTENSIONS.has(ext)) {
+        yield full;
+      }
+    }
+  }
+}
+
+function readCapped(path: string): string {
+  try {
+    const { size } = statSync(path);
+    if (size > MAX_BYTES_PER_FILE) return '';
+    return readFileSync(path, 'utf-8');
+  } catch {
+    return '';
+  }
+}
+
+export interface VerifyBaseUrlResult {
+  ok: boolean;
+  scannedFiles: number;
+  matchedFile?: string;
+}
+
+export function verifyBaseUrlInBundle(
+  directory: string,
+  pathPrefix: string
+): VerifyBaseUrlResult {
+  // The string we look for is the prefix without leading/trailing slashes.
+  // This matches both absolute (`/pr/123/`) and relative (`./pr/123/`) base
+  // URL emissions across frameworks.
+  const needle = pathPrefix.replace(/^\/+|\/+$/g, '');
+  if (!needle) {
+    return { ok: true, scannedFiles: 0 };
+  }
+
+  let scanned = 0;
+  for (const file of walk(directory)) {
+    if (scanned >= MAX_FILES) break;
+    scanned++;
+    const content = readCapped(file);
+    if (content.includes(needle)) {
+      return { ok: true, scannedFiles: scanned, matchedFile: file };
+    }
+  }
+  return { ok: false, scannedFiles: scanned };
+}
+
+export function assertBaseUrlInBundle(
+  directory: string,
+  pathPrefix: string
+): void {
+  if (process.env[SKIP_ENV_VAR] === 'true') {
+    logger.warn(
+      `Skipping base URL check because ${SKIP_ENV_VAR}=true was set.`
+    );
+    return;
+  }
+
+  const result = verifyBaseUrlInBundle(directory, pathPrefix);
+  if (result.ok) {
+    return;
+  }
+
+  const normalized = '/' + pathPrefix.replace(/^\/+|\/+$/g, '');
+  throw new Error(
+    [
+      `Preview deploy base URL check failed.`,
+      ``,
+      `Scanned ${result.scannedFiles} file(s) in ${directory} but found no references to "${pathPrefix}".`,
+      `This almost always means the build was not configured with a base URL matching the preview path prefix,`,
+      `and assets will 404 after deployment.`,
+      ``,
+      `Fix: rebuild with your framework's base URL set to "${normalized}/". Examples:`,
+      `  - Vite:    vite build --base=${normalized}/`,
+      `  - Next.js: set basePath: "${normalized}" in next.config.js`,
+      `  - Angular: ng build --base-href=${normalized}/`,
+      `  - Astro:   astro build --base=${normalized}`,
+      ``,
+      `Most CI workflows pass the prefix as an env var to the build step, e.g.`,
+      `    PATH_PREFIX=${normalized} VITE_BASE_URL=$PATH_PREFIX/ nx build my-app`,
+      ``,
+      `To bypass this check (not recommended) set ${SKIP_ENV_VAR}=true.`,
+    ].join('\n')
+  );
+}


### PR DESCRIPTION
## Summary

Integrates the PR preview deployment pattern (previously hand-rolled in [craigory-dev's workflows](https://github.com/agentender/craigory-dev/blob/main/.github/workflows/pr.yml)) directly into the `nx-github-pages` plugin, so any consumer can opt in with one generator invocation.

- **`deploy` executor** gains a `preview` option (`oneOf [false, { url?, pathPrefix?, comment? }]`) that clones the target branch, copies the build output into `<pathPrefix>/` (default `pr/${PR_NUMBER ?? GITHUB_SHA}`), pushes non-force (so sibling PRs are preserved), and upserts a PR comment with the preview URL via `@octokit/rest`.
- **New `cleanup-preview` executor** clones the deployment branch, removes `<pathPrefix>/*` directories older than `maxAgeDays` (using `git log -n 1 --pretty=format:%at` as the age source — no external metadata store needed), and updates the corresponding PR comments.
- **Base URL safeguard** scans the built bundle for references to the preview path prefix before pushing. If missing, the executor throws a multi-line error with framework-specific fix instructions (Vite / Next / Angular / Astro) and an `NX_GITHUB_PAGES_SKIP_BASE_URL_CHECK=true` escape hatch.
- **Configuration generator** gets `--preview`, `--previewUrl`, and `--addCleanupTarget` flags to scaffold the whole setup in one command.
- **`@octokit/rest`** is declared as an optional peer dep — users who never use preview mode don't pay the install cost; the utility lazy-`require`s it and warns gracefully when absent.

## Commits

1. `feat(deploy): add PR preview deploy mode`
2. `feat(cleanup-preview): add executor to prune stale PR previews`
3. `feat(configuration): add preview and cleanup generator options`
4. `feat(deploy): guard preview deploys with a base URL check`
5. `docs: document PR preview deployments`
6. `test(e2e): cover preview deploy, cleanup, and base URL guard`

## Test plan

- [x] `nx test nx-github-pages` — 19/19 passing (was 12, +7 new base-URL verifier tests)
- [x] `nx lint nx-github-pages` — 0 errors (1 pre-existing unused-var warning)
- [x] `nx lint e2e` — clean
- [x] `tsc --noEmit` on plugin + e2e tsconfigs — exit 0
- [ ] `nx e2e e2e` — **not run locally** (Verdaccio + real workspace + build; multi-minute). Will validate via CI.
- [ ] Smoke-test on a real workspace with `nx g nx-github-pages:configuration --preview`
- [ ] Verify the PR comment renders correctly on a real pull request
- [ ] Verify the scheduled cleanup workflow removes only directories older than `maxAgeDays`
- [ ] Verify the base URL safeguard fires with a readable error on a misconfigured build

## Notes for reviewers

- The base URL check is the one piece I'd most like a second opinion on. It's deliberately lenient (substring match against the normalized prefix across `.html/.js/.mjs/.cjs/.css/.map/.json` files) because different frameworks emit base URLs in different shapes. Strict HTML-attribute parsing would be more precise but more brittle. The env var bypass exists for legitimate CDN-rewrite setups.
- The preview flow deliberately reuses the existing `syncWithBaseBranch` configuration semantics where possible — it's a smaller diff than rewriting the git plumbing, and reviewers familiar with the existing sync logic will recognize the shape.
- E2E test "happy path" patches the generated Vite config (`base: process.env.BASE_URL ?? '/'`) rather than threading `--base` through `nx build -- --base=...`, which has been inconsistent across Nx versions. The `patchViteConfigWithBaseUrl` helper doubles as documentation for how consumers should wire it up themselves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)