### PR TITLE
fix(nx-github-pages): tolerate missing global git user when reading config

### DIFF
--- a/packages/nx-github-pages/src/executors/deploy/executor.ts
+++ b/packages/nx-github-pages/src/executors/deploy/executor.ts
@@ -112,10 +112,12 @@ export default async function deployExecutor(
   } else {
     const globalUserEmail = await exec('git config user.email', {
       cwd: directory,
-    });
+      stdio: 'ignore',
+    }).catch(() => '');
     const globalUserName = await exec('git config user.name', {
       cwd: directory,
-    });
+      stdio: 'ignore',
+    }).catch(() => '');
 
     if (!globalUserEmail || !globalUserName) {
       if (process.env.GITHUB_ACTIONS === 'true' && process.env.GITHUB_ACTOR) {


### PR DESCRIPTION
Reading user.email/user.name via `git config` exits non-zero when the
value isn't set, which caused the deploy executor to fail before it
could fall back to GITHUB_ACTOR. Swallow the read errors so the
existing fallback path can run.

https://claude.ai/code/session_01DUzoyrwz9LcAs4hViqhuqQ